### PR TITLE
Propagate streaming send interceptor errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -622,6 +622,7 @@ dependencies = [
  "bytes",
  "connectrpc-axum",
  "connectrpc-axum-build",
+ "connectrpc-axum-client",
  "flate2",
  "futures",
  "http",

--- a/connectrpc-axum-build/src/gen/client.rs
+++ b/connectrpc-axum-build/src/gen/client.rs
@@ -387,6 +387,7 @@ pub fn generate_connect_client(
 
                             let on_send = self.#interceptors_field.on_send.clone();
                             let procedure = #procedure_path.to_string();
+                            // Client-streaming awaits the unary response, so a post-call error slot is enough.
                             let interceptor_error: ::std::sync::Arc<::std::sync::Mutex<Option<connectrpc_axum_client::ClientError>>> =
                                 ::std::sync::Arc::new(::std::sync::Mutex::new(None));
                             let err_capture = interceptor_error.clone();
@@ -482,6 +483,9 @@ pub fn generate_connect_client(
                             let on_send = self.#interceptors_field.on_send.clone();
                             let procedure = #procedure_path.to_string();
                             let request_headers = connectrpc_axum_client::HeaderMap::new();
+                            // Bidi returns a receive stream, so send failures must wake parked receive polls.
+                            let interceptor_error = connectrpc_axum_client::SendInterceptorError::new();
+                            let err_capture = interceptor_error.clone();
 
                             // Use scan to apply interceptor; abort stream on first error
                             let wrapped = request.scan((), move |_state, mut msg| {
@@ -494,7 +498,10 @@ pub fn generate_connect_client(
                                     );
                                     match i.intercept(&ctx, &mut msg) {
                                         Ok(()) => ::std::future::ready(Some(msg)),
-                                        Err(_e) => ::std::future::ready(None), // Terminate send stream
+                                        Err(e) => {
+                                            err_capture.store(e);
+                                            ::std::future::ready(None)
+                                        }
                                     }
                                 } else {
                                     ::std::future::ready(Some(msg))
@@ -511,13 +518,16 @@ pub fn generate_connect_client(
                             // Wrap the response stream with typed interceptor
                             let on_receive = self.#interceptors_field.on_receive.clone();
                             Ok(response.map(|streaming| {
-                                connectrpc_axum_client::TypedReceiveStreaming::new(
+                                // Replace the generic receive wrapper with the generated typed wrapper.
+                                // Generated on_send errors are carried by interceptor_error below.
+                                connectrpc_axum_client::TypedReceiveStreaming::with_send_error_capture(
                                     streaming.get_inner(),
                                     on_receive,
                                     #procedure_path.to_string(),
                                     connectrpc_axum_client::StreamType::BidiStream,
                                     req_headers,
                                     response_headers,
+                                    interceptor_error,
                                 )
                             }))
                         }

--- a/connectrpc-axum-client/src/client.rs
+++ b/connectrpc-axum-client/src/client.rs
@@ -27,7 +27,7 @@ use crate::request::FrameEncoder;
 use crate::response::error_parser::parse_error_response;
 use crate::response::{
     ConnectResponse, FrameDecoder, InterceptingSendStream, InterceptingStreaming, Metadata,
-    Streaming,
+    SendInterceptorError, Streaming, take_send_interceptor_error,
 };
 
 /// Header name for Connect protocol version.
@@ -829,16 +829,19 @@ impl<I: InterceptorInternal> ConnectClient<I> {
         }
 
         // 3. Wrap request stream with InterceptingSendStream for per-message interception
-        let intercepting_stream = InterceptingSendStream::new(
+        // Client-streaming awaits the unary response, so captured send errors are checked before return.
+        let send_error = SendInterceptorError::new();
+        let intercepting_stream = InterceptingSendStream::with_send_error_capture(
             request,
             self.interceptor.clone(),
             procedure.to_string(),
             StreamType::ClientStream,
             interceptor_headers.clone(),
+            send_error.clone(),
         );
 
         // 4. Wrap with FrameEncoder
-        let encoder = FrameEncoder::new(
+        let encoder: FrameEncoder<_, Req> = FrameEncoder::new(
             intercepting_stream,
             self.use_proto,
             self.request_encoding,
@@ -892,15 +895,30 @@ impl<I: InterceptorInternal> ConnectClient<I> {
             .map_err(|e| ClientError::Protocol(format!("failed to build request: {}", e)))?;
 
         // 5. Send request (with client-side timeout if configured)
-        let response = if let Some(t) = effective_timeout {
-            timeout(t, self.transport.request(req))
-                .await
-                .map_err(|_| {
-                    ClientError::new(Code::DeadlineExceeded, "client timeout exceeded")
-                })??
+        let response_result = if let Some(t) = effective_timeout {
+            match timeout(t, self.transport.request(req)).await {
+                Ok(result) => result,
+                Err(_) => Err(ClientError::new(
+                    Code::DeadlineExceeded,
+                    "client timeout exceeded",
+                )),
+            }
         } else {
-            self.transport.request(req).await?
+            self.transport.request(req).await
         };
+        let response = match response_result {
+            Ok(response) => response,
+            Err(e) => {
+                if let Some(send_error) = take_send_interceptor_error(&send_error) {
+                    return Err(send_error);
+                }
+                return Err(e);
+            }
+        };
+
+        if let Some(send_error) = take_send_interceptor_error(&send_error) {
+            return Err(send_error);
+        }
 
         // 6. Check response status
         let status = response.status();
@@ -942,7 +960,12 @@ impl<I: InterceptorInternal> ConnectClient<I> {
         // 9. Get the single response message
         let message = match decoder.next().await {
             Some(Ok(msg)) => msg,
-            Some(Err(e)) => return Err(e),
+            Some(Err(e)) => {
+                if let Some(send_error) = take_send_interceptor_error(&send_error) {
+                    return Err(send_error);
+                }
+                return Err(e);
+            }
             None => {
                 return Err(ClientError::Protocol(
                     "expected response message but stream ended".to_string(),
@@ -955,6 +978,9 @@ impl<I: InterceptorInternal> ConnectClient<I> {
         if let Some(result) = decoder.next().await {
             match result {
                 Err(e) => {
+                    if let Some(send_error) = take_send_interceptor_error(&send_error) {
+                        return Err(send_error);
+                    }
                     // EndStream contained an error - propagate it
                     return Err(e);
                 }
@@ -966,6 +992,10 @@ impl<I: InterceptorInternal> ConnectClient<I> {
                     ));
                 }
             }
+        }
+
+        if let Some(send_error) = take_send_interceptor_error(&send_error) {
+            return Err(send_error);
         }
 
         // 11. Extract metadata from response headers
@@ -1135,16 +1165,19 @@ impl<I: InterceptorInternal> ConnectClient<I> {
         }
 
         // 3. Wrap request stream with InterceptingSendStream for per-message interception
-        let intercepting_stream = InterceptingSendStream::new(
+        // Bidi returns a receive stream, so captured send errors also wake pending receive polls.
+        let send_error = SendInterceptorError::new();
+        let intercepting_stream = InterceptingSendStream::with_send_error_capture(
             request,
             self.interceptor.clone(),
             procedure.to_string(),
             StreamType::BidiStream,
             interceptor_headers.clone(),
+            send_error.clone(),
         );
 
         // 4. Wrap with FrameEncoder
-        let encoder = FrameEncoder::new(
+        let encoder: FrameEncoder<_, Req> = FrameEncoder::new(
             intercepting_stream,
             self.use_proto,
             self.request_encoding,
@@ -1198,15 +1231,30 @@ impl<I: InterceptorInternal> ConnectClient<I> {
             .map_err(|e| ClientError::Protocol(format!("failed to build request: {}", e)))?;
 
         // 5. Send request (with client-side timeout if configured)
-        let response = if let Some(t) = effective_timeout {
-            timeout(t, self.transport.request(req))
-                .await
-                .map_err(|_| {
-                    ClientError::new(Code::DeadlineExceeded, "client timeout exceeded")
-                })??
+        let response_result = if let Some(t) = effective_timeout {
+            match timeout(t, self.transport.request(req)).await {
+                Ok(result) => result,
+                Err(_) => Err(ClientError::new(
+                    Code::DeadlineExceeded,
+                    "client timeout exceeded",
+                )),
+            }
         } else {
-            self.transport.request(req).await?
+            self.transport.request(req).await
         };
+        let response = match response_result {
+            Ok(response) => response,
+            Err(e) => {
+                if let Some(send_error) = take_send_interceptor_error(&send_error) {
+                    return Err(send_error);
+                }
+                return Err(e);
+            }
+        };
+
+        if let Some(send_error) = take_send_interceptor_error(&send_error) {
+            return Err(send_error);
+        }
 
         // 6. Verify HTTP/2 for bidirectional streaming
         // Bidi streaming requires HTTP/2 for full-duplex operation
@@ -1263,13 +1311,14 @@ impl<I: InterceptorInternal> ConnectClient<I> {
         let stream_body = Streaming::new(decoder);
 
         // 12. Wrap with InterceptingStreaming for per-message interception
-        let intercepting_stream = InterceptingStreaming::new(
+        let intercepting_stream = InterceptingStreaming::with_send_error_capture(
             stream_body,
             self.interceptor.clone(),
             procedure.to_string(),
             StreamType::BidiStream,
             interceptor_headers,
             response_headers.clone(),
+            send_error,
         );
 
         // 13. Extract metadata from initial response headers

--- a/connectrpc-axum-client/src/lib.rs
+++ b/connectrpc-axum-client/src/lib.rs
@@ -607,7 +607,7 @@ pub use request::FrameEncoder;
 // Re-export from response module
 pub use response::{
     ConnectResponse, FrameDecoder, InterceptingSendStream, InterceptingStream,
-    InterceptingStreaming, Metadata, Streaming, TypedReceiveStreaming,
+    InterceptingStreaming, Metadata, SendInterceptorError, Streaming, TypedReceiveStreaming,
 };
 
 // Re-export transport types at the top level for convenience

--- a/connectrpc-axum-client/src/request/encoder.rs
+++ b/connectrpc-axum-client/src/request/encoder.rs
@@ -31,8 +31,8 @@ enum EncoderState {
 
 /// Stream adapter that encodes messages into Connect protocol envelope frames.
 ///
-/// Wraps a stream of messages and yields framed bytes suitable for a streaming
-/// request body.
+/// Wraps a fallible stream of messages and yields framed bytes suitable for a
+/// streaming request body.
 ///
 /// # Frame Format
 ///
@@ -52,8 +52,8 @@ enum EncoderState {
 /// use futures::stream;
 ///
 /// let messages = stream::iter(vec![
-///     MyMessage { value: "hello".into() },
-///     MyMessage { value: "world".into() },
+///     Ok(MyMessage { value: "hello".into() }),
+///     Ok(MyMessage { value: "world".into() }),
 /// ]);
 ///
 /// let encoder = FrameEncoder::new(
@@ -85,7 +85,7 @@ impl<S, T> FrameEncoder<S, T> {
     ///
     /// # Arguments
     ///
-    /// * `stream` - The underlying message stream
+    /// * `stream` - The underlying fallible message stream
     /// * `use_proto` - Whether to use protobuf (true) or JSON (false) encoding
     /// * `encoding` - Compression encoding to use for outgoing messages
     /// * `compression` - Compression configuration (min_bytes threshold and level)
@@ -174,7 +174,7 @@ impl<S, T> Unpin for FrameEncoder<S, T> where S: Unpin {}
 
 impl<S, T> Stream for FrameEncoder<S, T>
 where
-    S: Stream<Item = T> + Unpin,
+    S: Stream<Item = Result<T, ClientError>> + Unpin,
     T: Message + Serialize,
 {
     type Item = Result<Bytes, ClientError>;
@@ -187,17 +187,20 @@ where
                 EncoderState::Streaming => {
                     // Poll the underlying stream for the next message
                     match Pin::new(&mut this.stream).poll_next(cx) {
-                        Poll::Ready(Some(msg)) => {
-                            // Encode the message into a frame
-                            match this.encode_frame(&msg) {
+                        Poll::Ready(Some(result)) => match result {
+                            Ok(msg) => match this.encode_frame(&msg) {
                                 Ok(frame) => return Poll::Ready(Some(Ok(frame))),
                                 Err(e) => {
                                     // On error, mark as done and return the error
                                     this.state = EncoderState::Done;
                                     return Poll::Ready(Some(Err(e)));
                                 }
+                            },
+                            Err(e) => {
+                                this.state = EncoderState::Done;
+                                return Poll::Ready(Some(Err(e)));
                             }
-                        }
+                        },
                         Poll::Ready(None) => {
                             // Inner stream exhausted, need to send EndStream
                             this.state = EncoderState::SendEndStream;
@@ -297,9 +300,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_single_json_message() {
-        let messages = stream::iter(vec![TestMessage {
+        let messages = stream::iter(vec![Ok(TestMessage {
             value: "hello".to_string(),
-        }]);
+        })]);
 
         let mut encoder = FrameEncoder::new(
             messages,
@@ -329,12 +332,12 @@ mod tests {
     #[tokio::test]
     async fn test_encode_multiple_messages() {
         let messages = stream::iter(vec![
-            TestMessage {
+            Ok(TestMessage {
                 value: "one".to_string(),
-            },
-            TestMessage {
+            }),
+            Ok(TestMessage {
                 value: "two".to_string(),
-            },
+            }),
         ]);
 
         let mut encoder = FrameEncoder::new(
@@ -368,9 +371,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_proto_message() {
-        let messages = stream::iter(vec![TestMessage {
+        let messages = stream::iter(vec![Ok(TestMessage {
             value: "hello".to_string(),
-        }]);
+        })]);
 
         let mut encoder = FrameEncoder::new(
             messages,
@@ -398,7 +401,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_encode_empty_stream() {
-        let messages = stream::iter(Vec::<TestMessage>::new());
+        let messages = stream::iter(Vec::<Result<TestMessage, ClientError>>::new());
 
         let mut encoder = FrameEncoder::new(
             messages,
@@ -413,5 +416,34 @@ mod tests {
 
         // Done
         assert!(encoder.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_fallible_message_stream_error_aborts_encoding() {
+        let messages = stream::iter(vec![
+            Ok(TestMessage {
+                value: "one".to_string(),
+            }),
+            Err(ClientError::invalid_argument("send blocked")),
+            Ok(TestMessage {
+                value: "two".to_string(),
+            }),
+        ]);
+
+        let mut encoder: FrameEncoder<_, TestMessage> = FrameEncoder::new(
+            messages,
+            false,
+            CompressionEncoding::Identity,
+            CompressionConfig::disabled(),
+        );
+
+        let frame = encoder.next().await.unwrap().unwrap();
+        assert_eq!(frame[0], 0x00);
+
+        let err = encoder.next().await.unwrap().unwrap_err();
+        assert_eq!(err.message(), Some("send blocked"));
+
+        assert!(encoder.next().await.is_none());
+        assert!(encoder.is_finished());
     }
 }

--- a/connectrpc-axum-client/src/response.rs
+++ b/connectrpc-axum-client/src/response.rs
@@ -15,8 +15,10 @@ mod streaming;
 mod types;
 
 pub use decoder::FrameDecoder;
+pub(crate) use intercepting::take_send_interceptor_error;
 pub use intercepting::{
-    InterceptingSendStream, InterceptingStream, InterceptingStreaming, TypedReceiveStreaming,
+    InterceptingSendStream, InterceptingStream, InterceptingStreaming, SendInterceptorError,
+    TypedReceiveStreaming,
 };
 pub use streaming::Streaming;
 pub use types::{ConnectResponse, Metadata};

--- a/connectrpc-axum-client/src/response/decoder.rs
+++ b/connectrpc-axum-client/src/response/decoder.rs
@@ -600,7 +600,8 @@ mod tests {
     #[tokio::test]
     async fn test_decode_compressed_end_stream_decompresses_trailers() {
         let codec = CompressionEncoding::Gzip.codec().unwrap();
-        let end_payload = br#"{"error":{"code":"internal","message":"boom"},"metadata":{"x-t":["1"]}}"#;
+        let end_payload =
+            br#"{"error":{"code":"internal","message":"boom"},"metadata":{"x-t":["1"]}}"#;
         let compressed = codec.compress(end_payload).unwrap();
         let end_frame = make_frame(0x03, &compressed);
 

--- a/connectrpc-axum-client/src/response/intercepting.rs
+++ b/connectrpc-axum-client/src/response/intercepting.rs
@@ -5,8 +5,8 @@
 
 use std::marker::PhantomData;
 use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
 
 use futures::Stream;
 use http::HeaderMap;
@@ -20,6 +20,80 @@ use crate::config::{InterceptorInternal, StreamContext, StreamType, TypedInterce
 use super::decoder::FrameDecoder;
 use super::streaming::Streaming;
 use super::types::Metadata;
+
+#[doc(hidden)]
+pub struct SendInterceptorError {
+    inner: Mutex<SendInterceptorErrorInner>,
+}
+
+#[derive(Default)]
+struct SendInterceptorErrorInner {
+    error: Option<ClientError>,
+    waker: Option<Waker>,
+}
+
+impl SendInterceptorError {
+    #[doc(hidden)]
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(SendInterceptorErrorInner::default()),
+        })
+    }
+
+    #[doc(hidden)]
+    pub fn store(&self, error: ClientError) {
+        let waker = {
+            let mut inner = self.inner.lock().unwrap();
+            if inner.error.is_none() {
+                inner.error = Some(error);
+            }
+            inner.waker.take()
+        };
+
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+
+    fn take(&self) -> Option<ClientError> {
+        self.inner.lock().unwrap().error.take()
+    }
+
+    fn take_or_register(&self, cx: &Context<'_>) -> Option<ClientError> {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(error) = inner.error.take() {
+            return Some(error);
+        }
+
+        match inner.waker.as_ref() {
+            Some(waker) if waker.will_wake(cx.waker()) => {}
+            _ => inner.waker = Some(cx.waker().clone()),
+        }
+
+        None
+    }
+}
+
+pub(crate) fn take_send_interceptor_error(
+    send_error: &Arc<SendInterceptorError>,
+) -> Option<ClientError> {
+    send_error.take()
+}
+
+fn take_optional_send_interceptor_error(
+    send_error: &Option<Arc<SendInterceptorError>>,
+) -> Option<ClientError> {
+    send_error.as_ref().and_then(|send_error| send_error.take())
+}
+
+fn take_or_register_optional_send_interceptor_error(
+    send_error: &Option<Arc<SendInterceptorError>>,
+    cx: &Context<'_>,
+) -> Option<ClientError> {
+    send_error
+        .as_ref()
+        .and_then(|send_error| send_error.take_or_register(cx))
+}
 
 /// A stream wrapper that intercepts incoming messages.
 ///
@@ -119,6 +193,162 @@ where
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{MessageInterceptor, MessageWrapper};
+    use futures::StreamExt;
+    use futures::stream;
+    use futures::task::{ArcWake, waker_ref};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Debug, PartialEq, Default)]
+    struct TestMessage {
+        value: String,
+    }
+
+    impl serde::Serialize for TestMessage {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            use serde::ser::SerializeStruct;
+            let mut state = serializer.serialize_struct("TestMessage", 1)?;
+            state.serialize_field("value", &self.value)?;
+            state.end()
+        }
+    }
+
+    impl prost::Message for TestMessage {
+        fn encode_raw(&self, buf: &mut impl bytes::BufMut)
+        where
+            Self: Sized,
+        {
+            if !self.value.is_empty() {
+                prost::encoding::string::encode(1, &self.value, buf);
+            }
+        }
+
+        fn merge_field(
+            &mut self,
+            tag: u32,
+            wire_type: prost::encoding::WireType,
+            buf: &mut impl bytes::Buf,
+            ctx: prost::encoding::DecodeContext,
+        ) -> Result<(), prost::DecodeError>
+        where
+            Self: Sized,
+        {
+            if tag == 1 {
+                prost::encoding::string::merge(wire_type, &mut self.value, buf, ctx)
+            } else {
+                prost::encoding::skip_field(wire_type, tag, buf, ctx)
+            }
+        }
+
+        fn encoded_len(&self) -> usize {
+            if self.value.is_empty() {
+                0
+            } else {
+                prost::encoding::string::encoded_len(1, &self.value)
+            }
+        }
+
+        fn clear(&mut self) {
+            self.value.clear();
+        }
+    }
+
+    #[derive(Clone)]
+    struct FailingSendInterceptor;
+
+    #[derive(Default)]
+    struct WakeCounter {
+        count: AtomicUsize,
+    }
+
+    impl ArcWake for WakeCounter {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    impl MessageInterceptor for FailingSendInterceptor {
+        fn on_stream_send<Req>(
+            &self,
+            _ctx: &StreamContext,
+            _request: &mut Req,
+        ) -> Result<(), ClientError>
+        where
+            Req: Message + Serialize + 'static,
+        {
+            Err(ClientError::invalid_argument("send blocked"))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_interceptor_error_is_returned_and_recorded() {
+        let send_error = SendInterceptorError::new();
+        let messages = stream::iter(vec![
+            TestMessage {
+                value: "one".to_string(),
+            },
+            TestMessage {
+                value: "two".to_string(),
+            },
+        ]);
+        let mut stream = InterceptingSendStream::with_send_error_capture(
+            messages,
+            MessageWrapper(FailingSendInterceptor),
+            "test.Service/ClientStream".to_string(),
+            StreamType::ClientStream,
+            HeaderMap::new(),
+            send_error.clone(),
+        );
+
+        let err = stream.next().await.unwrap().unwrap_err();
+        assert_eq!(err.message(), Some("send blocked"));
+
+        let recorded = take_send_interceptor_error(&send_error).unwrap();
+        assert_eq!(recorded.message(), Some("send blocked"));
+
+        assert!(stream.next().await.is_none());
+    }
+
+    #[test]
+    fn test_send_interceptor_error_wakes_pending_receive_stream() {
+        let send_error = SendInterceptorError::new();
+        let streaming = Streaming::new(stream::pending::<Result<TestMessage, ClientError>>());
+        let mut stream = TypedReceiveStreaming::with_send_error_capture(
+            streaming,
+            None,
+            "test.Service/BidiStream".to_string(),
+            StreamType::BidiStream,
+            HeaderMap::new(),
+            HeaderMap::new(),
+            send_error.clone(),
+        );
+        let wake_counter = Arc::new(WakeCounter::default());
+        let waker = waker_ref(&wake_counter);
+        let mut cx = Context::from_waker(&waker);
+
+        assert!(matches!(
+            Pin::new(&mut stream).poll_next(&mut cx),
+            Poll::Pending
+        ));
+
+        send_error.store(ClientError::invalid_argument("send blocked"));
+
+        assert_eq!(wake_counter.count.load(Ordering::SeqCst), 1);
+        match Pin::new(&mut stream).poll_next(&mut cx) {
+            Poll::Ready(Some(Err(e))) => {
+                assert_eq!(e.message(), Some("send blocked"));
+            }
+            other => panic!("expected send interceptor error, got {other:?}"),
+        }
+    }
+}
+
 /// A stream adapter that intercepts outgoing messages before encoding.
 ///
 /// This wraps an input stream and calls `intercept_stream_send` on each message
@@ -134,6 +364,10 @@ pub struct InterceptingSendStream<S, T, I> {
     stream_type: StreamType,
     /// Request headers (for context).
     request_headers: HeaderMap,
+    /// Shared send interceptor error storage.
+    send_error: Option<Arc<SendInterceptorError>>,
+    /// Whether an outbound interceptor error has aborted this stream.
+    aborted: bool,
     /// Marker for message type.
     _marker: PhantomData<T>,
 }
@@ -147,12 +381,51 @@ impl<S, T, I> InterceptingSendStream<S, T, I> {
         stream_type: StreamType,
         request_headers: HeaderMap,
     ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            None,
+        )
+    }
+
+    /// Create a new intercepting send stream that records send interceptor errors.
+    pub fn with_send_error_capture(
+        inner: S,
+        interceptor: I,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        send_error: Arc<SendInterceptorError>,
+    ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            Some(send_error),
+        )
+    }
+
+    fn new_inner(
+        inner: S,
+        interceptor: I,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        send_error: Option<Arc<SendInterceptorError>>,
+    ) -> Self {
         Self {
             inner,
             interceptor,
             procedure,
             stream_type,
             request_headers,
+            send_error,
+            aborted: false,
             _marker: PhantomData,
         }
     }
@@ -166,10 +439,14 @@ where
     T: Message + Serialize + 'static,
     I: InterceptorInternal,
 {
-    type Item = T;
+    type Item = Result<T, ClientError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
+
+        if this.aborted {
+            return Poll::Ready(None);
+        }
 
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(mut msg)) => {
@@ -181,13 +458,16 @@ where
                     None,
                 );
 
-                // Call interceptor - if it fails, we need to propagate the error
-                // But our Item type is T, not Result<T, E>
-                // So we'll log or silently ignore errors here
-                // TODO: Consider changing to Result<T, ClientError> if needed
-                let _ = this.interceptor.intercept_stream_send(&ctx, &mut msg);
-
-                Poll::Ready(Some(msg))
+                match this.interceptor.intercept_stream_send(&ctx, &mut msg) {
+                    Ok(()) => Poll::Ready(Some(Ok(msg))),
+                    Err(e) => {
+                        this.aborted = true;
+                        if let Some(ref send_error) = this.send_error {
+                            send_error.store(e.clone());
+                        }
+                        Poll::Ready(Some(Err(e)))
+                    }
+                }
             }
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
@@ -220,6 +500,8 @@ pub struct InterceptingStreaming<S, T, I> {
     request_headers: HeaderMap,
     /// Response headers.
     response_headers: HeaderMap,
+    /// Shared send interceptor error storage.
+    send_error: Option<Arc<SendInterceptorError>>,
     /// Marker for message type.
     _marker: PhantomData<T>,
 }
@@ -234,6 +516,47 @@ impl<S, T, I> InterceptingStreaming<S, T, I> {
         request_headers: HeaderMap,
         response_headers: HeaderMap,
     ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            response_headers,
+            None,
+        )
+    }
+
+    /// Create a new intercepting streaming wrapper that can yield send interceptor errors.
+    pub fn with_send_error_capture(
+        inner: Streaming<S>,
+        interceptor: I,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        response_headers: HeaderMap,
+        send_error: Arc<SendInterceptorError>,
+    ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            response_headers,
+            Some(send_error),
+        )
+    }
+
+    fn new_inner(
+        inner: Streaming<S>,
+        interceptor: I,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        response_headers: HeaderMap,
+        send_error: Option<Arc<SendInterceptorError>>,
+    ) -> Self {
         Self {
             inner,
             interceptor,
@@ -241,6 +564,7 @@ impl<S, T, I> InterceptingStreaming<S, T, I> {
             stream_type,
             request_headers,
             response_headers,
+            send_error,
             _marker: PhantomData,
         }
     }
@@ -298,8 +622,16 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
+        if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+            return Poll::Ready(Some(Err(e)));
+        }
+
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(mut msg))) => {
+                if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+                    return Poll::Ready(Some(Err(e)));
+                }
+
                 // Create stream context
                 let ctx = StreamContext::new(
                     &this.procedure,
@@ -314,9 +646,40 @@ where
                     Err(e) => Poll::Ready(Some(Err(e))),
                 }
             }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Err(e))) => {
+                if let Some(send_error) = take_optional_send_interceptor_error(&this.send_error) {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(
+                        procedure = this.procedure.as_str(),
+                        receive_error = %&e,
+                        send_interceptor_error = %&send_error,
+                        "receive stream error suppressed by send interceptor error"
+                    );
+
+                    Poll::Ready(Some(Err(send_error)))
+                } else {
+                    Poll::Ready(Some(Err(e)))
+                }
+            }
+            Poll::Ready(None) => {
+                // Only an already-captured send error can replace stream completion. If a bidi
+                // send failure is discovered after this returns None, there is no receive poll left
+                // to observe it.
+                if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+                    Poll::Ready(Some(Err(e)))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+            Poll::Pending => {
+                if let Some(e) =
+                    take_or_register_optional_send_interceptor_error(&this.send_error, cx)
+                {
+                    Poll::Ready(Some(Err(e)))
+                } else {
+                    Poll::Pending
+                }
+            }
         }
     }
 
@@ -346,6 +709,8 @@ pub struct TypedReceiveStreaming<S, T> {
     request_headers: HeaderMap,
     /// Response headers.
     response_headers: HeaderMap,
+    /// Shared send interceptor error storage.
+    send_error: Option<Arc<SendInterceptorError>>,
 }
 
 impl<S, T> TypedReceiveStreaming<S, T> {
@@ -358,6 +723,47 @@ impl<S, T> TypedReceiveStreaming<S, T> {
         request_headers: HeaderMap,
         response_headers: HeaderMap,
     ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            response_headers,
+            None,
+        )
+    }
+
+    /// Create a new typed receive stream that can yield send interceptor errors.
+    pub fn with_send_error_capture(
+        inner: Streaming<S>,
+        interceptor: Option<Arc<dyn for<'a> TypedInterceptor<StreamContext<'a>, T>>>,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        response_headers: HeaderMap,
+        send_error: Arc<SendInterceptorError>,
+    ) -> Self {
+        Self::new_inner(
+            inner,
+            interceptor,
+            procedure,
+            stream_type,
+            request_headers,
+            response_headers,
+            Some(send_error),
+        )
+    }
+
+    fn new_inner(
+        inner: Streaming<S>,
+        interceptor: Option<Arc<dyn for<'a> TypedInterceptor<StreamContext<'a>, T>>>,
+        procedure: String,
+        stream_type: StreamType,
+        request_headers: HeaderMap,
+        response_headers: HeaderMap,
+        send_error: Option<Arc<SendInterceptorError>>,
+    ) -> Self {
         Self {
             inner,
             interceptor,
@@ -365,6 +771,7 @@ impl<S, T> TypedReceiveStreaming<S, T> {
             stream_type,
             request_headers,
             response_headers,
+            send_error,
         }
     }
 }
@@ -413,8 +820,16 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.get_mut();
 
+        if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+            return Poll::Ready(Some(Err(e)));
+        }
+
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(mut msg))) => {
+                if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+                    return Poll::Ready(Some(Err(e)));
+                }
+
                 // If there's an interceptor, call it
                 if let Some(ref interceptor) = this.interceptor {
                     let ctx = StreamContext::new(
@@ -432,9 +847,40 @@ where
                     Poll::Ready(Some(Ok(msg)))
                 }
             }
-            Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+            Poll::Ready(Some(Err(e))) => {
+                if let Some(send_error) = take_optional_send_interceptor_error(&this.send_error) {
+                    #[cfg(feature = "tracing")]
+                    tracing::debug!(
+                        procedure = this.procedure.as_str(),
+                        receive_error = %&e,
+                        send_interceptor_error = %&send_error,
+                        "receive stream error suppressed by send interceptor error"
+                    );
+
+                    Poll::Ready(Some(Err(send_error)))
+                } else {
+                    Poll::Ready(Some(Err(e)))
+                }
+            }
+            Poll::Ready(None) => {
+                // Only an already-captured send error can replace stream completion. If a bidi
+                // send failure is discovered after this returns None, there is no receive poll left
+                // to observe it.
+                if let Some(e) = take_optional_send_interceptor_error(&this.send_error) {
+                    Poll::Ready(Some(Err(e)))
+                } else {
+                    Poll::Ready(None)
+                }
+            }
+            Poll::Pending => {
+                if let Some(e) =
+                    take_or_register_optional_send_interceptor_error(&this.send_error, cx)
+                {
+                    Poll::Ready(Some(Err(e)))
+                } else {
+                    Poll::Pending
+                }
+            }
         }
     }
 

--- a/connectrpc-axum-test/Cargo.toml
+++ b/connectrpc-axum-test/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 connectrpc-axum = { path = "../connectrpc-axum", features = ["tonic", "compression-full"] }
+connectrpc-axum-client = { path = "../connectrpc-axum-client" }
 axum = { workspace = true }
 prost = { workspace = true }
 pbjson = { workspace = true }

--- a/connectrpc-axum-test/features/05-streaming-core.feature
+++ b/connectrpc-axum-test/features/05-streaming-core.feature
@@ -41,7 +41,7 @@ Feature: connectrpc-axum-test integration behavior — streaming core
   # Source refs:
   # - connectrpc-axum-test/src/connect_bidi_stream.rs (orchestrator)
   # - connectrpc-axum-test/src/connect_bidi_stream/server.rs (Rust server: EchoBidiStream handler)
-  # - connectrpc-axum-test/src/connect_bidi_stream/client.rs (Rust client: HTTP/1.1 half-duplex, HTTP/2 for Go server)
+  # - connectrpc-axum-test/src/connect_bidi_stream/client.rs (Rust client: HTTP/1.1 half-duplex, HTTP/2 for Go server, send-interceptor wake test)
   # - connectrpc-axum-test/go/connect_bidi_stream/server/server.go (Go server: h2c, requires HTTP/2 for bidi)
   # - connectrpc-axum-test/go/connect_bidi_stream/client/client.go (Go client: HTTP/2 h2c transport)
 
@@ -51,4 +51,9 @@ Feature: connectrpc-axum-test integration behavior — streaming core
     Then the response contains at least 3 echo responses
     And the first echo contains "Echo #1"
 
+  Scenario: connect_bidi_stream — send interceptor error wakes pending receive
+    Given a Rust Connect client opens an HTTP/2 bidirectional stream
+    And the receive side is waiting for the next response
+    When an on_send interceptor rejects the next request message
+    Then the receive side returns that send interceptor error instead of timing out
 

--- a/connectrpc-axum-test/integration-tests.feature
+++ b/connectrpc-axum-test/integration-tests.feature
@@ -6,7 +6,7 @@ Feature: connectrpc-axum-test integration behavior
     - features/02-errors-metadata.feature
     - features/03-size-limits.feature
     - features/04-auth-extractors.feature
-    - features/05-streaming-core.feature
+    - features/05-streaming-core.feature (includes bidi send-interceptor error propagation)
     - features/06-compression.feature
     - features/07-tonic-grpc.feature
     - features/08-routing.feature

--- a/connectrpc-axum-test/src/connect_bidi_stream.rs
+++ b/connectrpc-axum-test/src/connect_bidi_stream.rs
@@ -26,6 +26,9 @@ pub async fn run(rust_sock: &TestSocket, go_sock: &TestSocket) -> anyhow::Result
 
     let rust_listener = rust_sock.bind()?;
     let rust_server = tokio::spawn(server::start(rust_listener));
+    let rust_tcp_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let rust_tcp_addr = rust_tcp_listener.local_addr()?;
+    let rust_tcp_server = tokio::spawn(server::start_tcp(rust_tcp_listener));
 
     let mut go_server = Command::new(&go_server_bin)
         .env("SOCKET_PATH", go_sock.go_addr())
@@ -37,14 +40,16 @@ pub async fn run(rust_sock: &TestSocket, go_sock: &TestSocket) -> anyhow::Result
 
     println!("=== Connect Bidi Stream Integration Tests ===");
 
-    let (rs_go, rs_rs, go_go, go_rs) = tokio::join!(
+    let (rs_go, rs_rs, go_go, go_rs, interceptor_cases) = tokio::join!(
         run_go_client(rust_sock, &go_client_bin),
         client::run_bidi_stream_tests(rust_sock),
         run_go_client(go_sock, &go_client_bin),
         client::run_bidi_stream_tests_h2(go_sock),
+        client::run_bidi_stream_interceptor_tests(rust_tcp_addr),
     );
 
     rust_server.abort();
+    rust_tcp_server.abort();
     go_server.kill().await.ok();
 
     let mut total = 0;
@@ -77,6 +82,7 @@ pub async fn run(rust_sock: &TestSocket, go_sock: &TestSocket) -> anyhow::Result
     };
     report_rust("Rust Server + Rust Client", rs_rs);
     report_rust("Go Server + Rust Client", go_rs);
+    report_rust("Rust TCP Server + Rust Client", interceptor_cases);
 
     println!();
     println!("{passed}/{total} passed");

--- a/connectrpc-axum-test/src/connect_bidi_stream/client.rs
+++ b/connectrpc-axum-test/src/connect_bidi_stream/client.rs
@@ -1,10 +1,22 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
 use bytes::Bytes;
+use connectrpc_axum_client::{ClientError, ConnectClient, MessageInterceptor, StreamContext};
+use futures::StreamExt;
 use http::Request;
 use http_body_util::{BodyExt, Full};
 use hyper::client::conn::http1;
 use hyper_util::rt::TokioIo;
+use prost::Message;
+use serde::Serialize;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
 
 use crate::socket::TestSocket;
+use crate::{EchoRequest, EchoResponse};
 
 pub struct CaseResult {
     pub name: &'static str,
@@ -35,6 +47,96 @@ pub async fn run_bidi_stream_tests_h2(sock: &TestSocket) -> Vec<CaseResult> {
         name: "bidi stream echoes messages",
         error: err,
     }]
+}
+
+pub async fn run_bidi_stream_interceptor_tests(addr: SocketAddr) -> Vec<CaseResult> {
+    let err = run_send_interceptor_wakes_receive(addr)
+        .await
+        .err()
+        .map(|e| e.to_string());
+    vec![CaseResult {
+        name: "bidi send interceptor wakes pending receive",
+        error: err,
+    }]
+}
+
+#[derive(Clone, Default)]
+struct FailSecondSend {
+    sent: Arc<AtomicUsize>,
+}
+
+impl MessageInterceptor for FailSecondSend {
+    fn on_stream_send<Req>(
+        &self,
+        _ctx: &StreamContext,
+        _request: &mut Req,
+    ) -> Result<(), ClientError>
+    where
+        Req: Message + Serialize + 'static,
+    {
+        if self.sent.fetch_add(1, Ordering::SeqCst) == 0 {
+            Ok(())
+        } else {
+            Err(ClientError::invalid_argument("send blocked"))
+        }
+    }
+}
+
+async fn run_send_interceptor_wakes_receive(addr: SocketAddr) -> anyhow::Result<()> {
+    let (request_tx, request_rx) = mpsc::channel(2);
+    let (first_seen_tx, first_seen_rx) = oneshot::channel();
+
+    let client = ConnectClient::builder(&format!("http://{addr}"))
+        .http2_prior_knowledge()
+        .with_message_interceptor(FailSecondSend::default())
+        .build()?;
+    let receive = tokio::spawn(async move {
+        let response = client
+            .call_bidi_stream::<EchoRequest, EchoResponse, _>(
+                "echo.EchoService/EchoBidiStream",
+                ReceiverStream::new(request_rx),
+            )
+            .await?;
+        let mut stream = response.into_inner();
+
+        let first = tokio::time::timeout(Duration::from_secs(2), stream.next())
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out waiting for first bidi response"))?
+            .ok_or_else(|| anyhow::anyhow!("expected first bidi response, got stream end"))??;
+        if !first.message.contains("Echo #1") {
+            anyhow::bail!("expected first echo response, got {}", first.message);
+        }
+
+        let _ = first_seen_tx.send(());
+
+        match tokio::time::timeout(Duration::from_secs(2), stream.next()).await {
+            Ok(Some(Err(e))) if e.message() == Some("send blocked") => Ok(()),
+            Ok(Some(Err(e))) => anyhow::bail!("expected send blocked error, got {e}"),
+            Ok(Some(Ok(msg))) => anyhow::bail!("expected send error, got message {}", msg.message),
+            Ok(None) => anyhow::bail!("expected send error, got stream end"),
+            Err(_) => anyhow::bail!("pending receive was not woken by send interceptor error"),
+        }
+    });
+
+    request_tx
+        .send(EchoRequest {
+            message: "first".to_string(),
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("request stream closed before first send"))?;
+
+    first_seen_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("receive task ended before first response"))?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    request_tx
+        .send(EchoRequest {
+            message: "second".to_string(),
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("request stream closed before second send"))?;
+
+    receive.await?
 }
 
 /// Bidi stream over HTTP/1.1 (half-duplex, works with Rust server)

--- a/connectrpc-axum-test/src/connect_bidi_stream/server.rs
+++ b/connectrpc-axum-test/src/connect_bidi_stream/server.rs
@@ -1,6 +1,7 @@
 use crate::{EchoRequest, EchoResponse, echo_service_connect};
 use connectrpc_axum::prelude::*;
 use futures::{Stream, StreamExt};
+use tokio::net::{TcpListener, UnixListener};
 
 async fn echo_bidi_stream(
     ConnectRequest(streaming): ConnectRequest<Streaming<EchoRequest>>,
@@ -34,15 +35,22 @@ async fn echo_bidi_stream(
     Ok(ConnectResponse::new(StreamBody::new(response_stream)))
 }
 
-pub async fn start(listener: tokio::net::UnixListener) -> anyhow::Result<()> {
+fn app() -> axum::Router<()> {
     let router = echo_service_connect::EchoServiceBuilder::new()
         .echo_bidi_stream(echo_bidi_stream)
         .build();
 
-    let app = connectrpc_axum::MakeServiceBuilder::new()
+    connectrpc_axum::MakeServiceBuilder::new()
         .add_router(router)
-        .build();
+        .build()
+}
 
-    axum::serve(listener, app).await?;
+pub async fn start(listener: UnixListener) -> anyhow::Result<()> {
+    axum::serve(listener, app()).await?;
+    Ok(())
+}
+
+pub async fn start_tcp(listener: TcpListener) -> anyhow::Result<()> {
+    axum::serve(listener, app()).await?;
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Return and record generic streaming send-interceptor errors instead of sending the rejected message.
- Thread captured send errors through generic client-streaming and bidirectional streaming calls so the original `ClientError` is returned or yielded by the response stream.
- Wake pending bidi receive streams when the send side captures an interceptor error, avoiding a parked `next()` future waiting until timeout.
- Change `FrameEncoder` to accept fallible message streams (`Stream<Item = Result<T, ClientError>>`) so outbound encoding has one error channel.
- Update generated bidi clients to surface typed `on_send` failures.

## Testing
- `cargo check -p connectrpc-axum-client -p connectrpc-axum-build`
- `cargo test -p connectrpc-axum-client`
- `cargo test -p connectrpc-axum-build`
- `cargo fmt --check`
- `cargo run -p connectrpc-axum-test`

## Notes
- `FrameEncoder` direct public usage is now source-breaking for callers passing `Stream<Item = T>`; callers should pass `Stream<Item = Result<T, ClientError>>`.
- `cargo make ci` currently fails before running because `Makefile.toml` references an undefined `fmt-check` task.
- Workspace Clippy with `-D warnings` currently fails on existing unrelated lints in `connectrpc-axum-core`, `connectrpc-axum-build`, and `connectrpc-axum-client`.
